### PR TITLE
clip history to model context

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -23,8 +23,6 @@ class BaseAgent:
         self.paper_summary = str()
         self.data_summary = str()
         self.max_hist_len = 5
-        # limit on history tokens to stay within model context window
-        self.max_history_tokens = 180000
 
     def set_model_backbone(self, model):
         self.model = model
@@ -40,9 +38,7 @@ class BaseAgent:
 
     def inference(self, instruction, phase, step, feedback="", info=None, image=None, temp=None, use_command=True):
         # context = self.context(phase)
-        history_messages = [{"role": "user", "content": _[1]} for _ in self.history]
-        history_messages = clip_tokens(history_messages, model=self.model, max_tokens=self.max_history_tokens)
-        history_str = "\n".join([m["content"] for m in history_messages])
+        history_str = "\n".join([_[1] for _ in self.history])
         phase_notes = [_note["note"] for _note in self.notes if phase in _note["phases"]]
         notes_str = f"Notes for the task objective: {phase_notes}\n" if phase_notes else ""
         if use_command == True:

--- a/agents.py
+++ b/agents.py
@@ -23,6 +23,8 @@ class BaseAgent:
         self.paper_summary = str()
         self.data_summary = str()
         self.max_hist_len = 5
+        # limit on history tokens to stay within model context window
+        self.max_history_tokens = 180000
 
     def set_model_backbone(self, model):
         self.model = model
@@ -38,7 +40,9 @@ class BaseAgent:
 
     def inference(self, instruction, phase, step, feedback="", info=None, image=None, temp=None, use_command=True):
         # context = self.context(phase)
-        history_str = "\n".join([_[1] for _ in self.history])
+        history_messages = [{"role": "user", "content": _[1]} for _ in self.history]
+        history_messages = clip_tokens(history_messages, model=self.model, max_tokens=self.max_history_tokens)
+        history_str = "\n".join([m["content"] for m in history_messages])
         phase_notes = [_note["note"] for _note in self.notes if phase in _note["phases"]]
         notes_str = f"Notes for the task objective: {phase_notes}\n" if phase_notes else ""
         if use_command == True:

--- a/utils.py
+++ b/utils.py
@@ -71,8 +71,17 @@ def save_to_file(location, filename, data):
     except Exception as e:
         print(f"Error saving file {filename}: {e}")
 
-def clip_tokens(messages, model="gpt-4", max_tokens=100000):
-    enc = tiktoken.encoding_for_model(model)
+def clip_tokens(messages, model="gpt-4", max_tokens=200000):
+    """Clip a list of messages so total tokens do not exceed ``max_tokens``.
+
+    The default limit (200k) matches the context window of GPT-5 models.
+    """
+    if model in ["o1-mini", "claude-3-5-sonnet", "o3-mini"]:
+        enc = tiktoken.encoding_for_model("gpt-4o")
+    elif model in ["deepseek-chat", "deepseek-r1"]:
+        enc = tiktoken.encoding_for_model("cl100k_base")
+    else:
+        enc = tiktoken.encoding_for_model(model)
     total_tokens = sum([len(enc.encode(message["content"])) for message in messages])
 
     if total_tokens <= max_tokens:


### PR DESCRIPTION
## Summary
- clip agent histories to configured token limit before prompting
- bump default token cap to 200k and support more model names in token clipping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7698c3408328b93ce865e7478912