### PR TITLE
Add gpt-5 support and expand token limit to 200k

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -3,7 +3,7 @@ from tools import *
 from inference import *
 
 class BaseAgent:
-    def __init__(self, model="gpt-4o-mini", notes=None, max_steps=100):
+    def __init__(self, model="gpt-5", notes=None, max_steps=100):
         if notes is None: self.notes = []
         else: self.notes = notes
         self.max_steps = max_steps
@@ -98,7 +98,7 @@ class BaseAgent:
 
 
 class ResearchAgent(BaseAgent):
-    def __init__(self, model="gpt4omini", notes=None, max_steps=100, task_instruction=None):
+    def __init__(self, model="gpt-5", notes=None, max_steps=100, task_instruction=None):
         super().__init__(model, notes, max_steps)
         self.phases = [
             "overall summary",
@@ -232,7 +232,7 @@ class ResearchAgent(BaseAgent):
 
 
 class CodeAgent(BaseAgent):
-    def __init__(self, model="o1-preview", notes=None, max_steps=100, dataloader_code=None, task_instruction=None):
+    def __init__(self, model="gpt-5", notes=None, max_steps=100, dataloader_code=None, task_instruction=None):
         super().__init__(model, notes, max_steps)
         self.phases = [
             "paper lineage",

--- a/utils.py
+++ b/utils.py
@@ -39,8 +39,11 @@ def compile_latex(latex_code, compile=True, output_filename="output.pdf", timeou
         # If there is an error during LaTeX compilation, return the error message
         return f"[CODE EXECUTION ERROR]: Compilation failed: {e.stderr.decode('utf-8')} {e.output.decode('utf-8')}. There was an error in your latex."
 
-def count_tokens(messages, model="gpt-4"):
-    enc = tiktoken.encoding_for_model(model)
+def count_tokens(messages, model="gpt-5"):
+    try:
+        enc = tiktoken.encoding_for_model(model)
+    except KeyError:
+        enc = tiktoken.get_encoding("o200k_base")
     num_tokens = sum([len(enc.encode(message["content"])) for message in messages])
     return num_tokens
 
@@ -71,8 +74,11 @@ def save_to_file(location, filename, data):
     except Exception as e:
         print(f"Error saving file {filename}: {e}")
 
-def clip_tokens(messages, model="gpt-4", max_tokens=100000):
-    enc = tiktoken.encoding_for_model(model)
+def clip_tokens(messages, model="gpt-5", max_tokens=200000):
+    try:
+        enc = tiktoken.encoding_for_model(model)
+    except KeyError:
+        enc = tiktoken.get_encoding("o200k_base")
     total_tokens = sum([len(enc.encode(message["content"])) for message in messages])
 
     if total_tokens <= max_tokens:


### PR DESCRIPTION
## Summary
- default all agents to gpt-5
- support gpt-5 in query_model with cost estimates and 200k-token encoding
- raise token clipping and counting utilities to 200k max tokens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68accbfa614c832881ec4aeae98d1050